### PR TITLE
[MSHARED-1344] Support for tsapolicyid and tsadigestalg

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   </parent>
 
   <artifactId>maven-jarsigner</artifactId>
-  <version>3.0.1-SNAPSHOT</version>
+  <version>3.1.0-SNAPSHOT</version>
 
   <name>Apache Maven Jarsigner</name>
   <description>A component to assist in signing jars.</description>

--- a/src/main/java/org/apache/maven/shared/jarsigner/JarSignerCommandLineBuilder.java
+++ b/src/main/java/org/apache/maven/shared/jarsigner/JarSignerCommandLineBuilder.java
@@ -173,6 +173,18 @@ public class JarSignerCommandLineBuilder {
             cli.createArg().setValue(tsaAlias);
         }
 
+        String tsapolicyid = request.getTsapolicyid();
+        if (StringUtils.isNotBlank(tsapolicyid)) {
+            cli.createArg().setValue("-tsapolicyid");
+            cli.createArg().setValue(tsapolicyid);
+        }
+
+        String tsadigestalg = request.getTsadigestalg();
+        if (StringUtils.isNotBlank(tsadigestalg)) {
+            cli.createArg().setValue("-tsadigestalg");
+            cli.createArg().setValue(tsadigestalg);
+        }
+
         File signedjar = request.getSignedjar();
         if (signedjar != null) {
             cli.createArg().setValue("-signedjar");

--- a/src/main/java/org/apache/maven/shared/jarsigner/JarSignerSignRequest.java
+++ b/src/main/java/org/apache/maven/shared/jarsigner/JarSignerSignRequest.java
@@ -29,34 +29,55 @@ import java.io.File;
 public class JarSignerSignRequest extends AbstractJarSignerRequest {
 
     /**
-     * See <a href="http://docs.oracle.com/javase/6/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.
+     * See <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html#CCHIFIAD">options</a>.
      */
     private String keypass;
 
     /**
-     * See <a href="http://docs.oracle.com/javase/6/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.
+     * See <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html#CCHIFIAD">options</a>.
      */
     private String sigfile;
 
     /**
-     * See <a href="http://docs.oracle.com/javase/6/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.
+     * The {@code -tsa} parameter, the URL to the Time Stamping Authority (TSA) server.
+     * See <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html#CCHIFIAD">options</a>.
      */
     private String tsaLocation;
 
     /**
-     * See <a href="http://docs.oracle.com/javase/6/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.
+     * The {@code -tsacert} parameter. Alias for a certificate in the active keystore. From the certificate the X509v3
+     * extension "Subject Information Access" field is examined to find a TSA server URL.
+     * See <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html#CCHIFIAD">options</a>.
      */
     private String tsaAlias;
 
     /**
-     * See <a href="http://docs.oracle.com/javase/6/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.
+     * The {@code -tsapolicyid} parameter, an OID to send to the TSA server to identify the policy ID the server should
+     * use. See
+     * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html#CCHIFIAD">options</a>.
+     *
+     * @since 3.1.0
+     */
+    private String tsapolicyid;
+
+    /**
+     * The {@code -tsadigestalg} parameter, the message digest algorithm for TSA server to use. Only available in Java
+     * 11 and later. See
+     * <a href="https://docs.oracle.com/en/java/javase/11/tools/jarsigner.html">options</a>.
+     *
+     * @since 3.1.0
+     */
+    private String tsadigestalg;
+
+    /**
+     * See <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html#CCHIFIAD">options</a>.
      */
     protected File signedjar;
 
     /**
      * Location of the extra certchain file to be used during signing.
      *
-     * See <a href="http://docs.oracle.com/javase/7/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.
+     * See <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html#CCHIFIAD">options</a>.
      * @since 3.0.0
      */
     protected File certchain;
@@ -77,6 +98,14 @@ public class JarSignerSignRequest extends AbstractJarSignerRequest {
         return tsaAlias;
     }
 
+    public String getTsapolicyid() {
+        return tsapolicyid;
+    }
+
+    public String getTsadigestalg() {
+        return tsadigestalg;
+    }
+
     public void setKeypass(String keypass) {
         this.keypass = keypass;
     }
@@ -91,6 +120,14 @@ public class JarSignerSignRequest extends AbstractJarSignerRequest {
 
     public void setTsaAlias(String tsaAlias) {
         this.tsaAlias = tsaAlias;
+    }
+
+    public void setTsapolicyid(String tsapolicyid) {
+        this.tsapolicyid = tsapolicyid;
+    }
+
+    public void setTsadigestalg(String tsadigestalg) {
+        this.tsadigestalg = tsadigestalg;
     }
 
     public File getSignedjar() {


### PR DESCRIPTION
Implementation of https://issues.apache.org/jira/browse/MSHARED-1344. Will add the possibility to use `-tsapolicyid` and `-tsadigestalg`. Note that `-tsadigestalg` is not available in Java 8, but exist in Java 11.

I also increased the next build number to 3.1.0 since this is a new feature. 

When testing both parameters works. Example command with policy (see [OID 2.16.840.1.114412.7.1](http://www.oid-info.com/cgi-bin/display?oid=2.16.840.1.114412.7&submit=Display&action=display)) that will work with the DigiCert TSA server:
```
jarsigner -keystore codesignkeystore.jks -storepass password1234 -tsa http://timestamp.digicert.com -tsapolicyid 2.16.840.1.114412.7.1 -tsadigestalg SHA-512 helloworld.jar codesignkey
```
